### PR TITLE
Add pods exec resource

### DIFF
--- a/cluster-preparation.md
+++ b/cluster-preparation.md
@@ -76,7 +76,7 @@ metadata:
   name: tower-launcher-role
 rules:
   - apiGroups: [""]
-    resources: ["pods", "pods/status", "pods/log", "jobs", "jobs/status", "jobs/log"]
+    resources: ["pods", "pods/status", "pods/log", "pods/exec", "jobs", "jobs/status", "jobs/log"]
     verbs: ["get", "list", "watch", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This was already set at the example `yaml` file but not at the `cluster-preparation.md` description. 